### PR TITLE
WILL-694 - Adding caching to the plugin

### DIFF
--- a/src/Commands/WarmStorage.php
+++ b/src/Commands/WarmStorage.php
@@ -23,13 +23,10 @@ class WarmStorage
     public function warm()
     {
         $facebookRepo = new FacebookRepository();
-        if ($facebookRepo->isActive() && $posts = $facebookRepo->fetchInstagramPosts()) {
-            Storage::set(FacebookRepository::STORAGE_KEY, $posts);
-        }
+        $facebookRepo->storeInstagramPosts();
+
         $pinterestRepo = new PinterestRepository();
-        if ($pinterestRepo->isActive() && $pins = $pinterestRepo->fetchPins()) {
-            Storage::set(PinterestRepository::STORAGE_KEY, $pins);
-        }
+        $pinterestRepo->storePins();
 
         WP_CLI::success('Social Feed Storage Warmed!');
     }

--- a/src/Commands/WarmStorage.php
+++ b/src/Commands/WarmStorage.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Bonnier\WP\SoMe\Commands;
+
+use Bonnier\WP\SoMe\Helpers\Storage;
+use Bonnier\WP\SoMe\Repositories\FacebookRepository;
+use Bonnier\WP\SoMe\Repositories\PinterestRepository;
+use WP_CLI;
+
+class WarmStorage
+{
+    public static function register()
+    {
+        WP_CLI::add_command('bonnier some', __CLASS__);
+    }
+
+    /**
+     * Warms the SocialFeed storage
+     *
+     * ## EXAMPLE
+     *     wp bonnier some warm
+     */
+    public function warm()
+    {
+        $facebookRepo = new FacebookRepository();
+        if ($facebookRepo->isActive() && $posts = $facebookRepo->fetchInstagramPosts()) {
+            Storage::set(FacebookRepository::STORAGE_KEY, $posts);
+        }
+        $pinterestRepo = new PinterestRepository();
+        if ($pinterestRepo->isActive() && $pins = $pinterestRepo->fetchPins()) {
+            Storage::set(PinterestRepository::STORAGE_KEY, $pins);
+        }
+
+        WP_CLI::success('Social Feed Storage Warmed!');
+    }
+
+    /**
+     * Inspect the SocialFeed storage
+     *
+     * ## OPTIONS
+     *
+     * <provider>
+     * : The name of the Service Provider
+     * ---
+     * options:
+     *   - facebook
+     *   - pinterest
+     * ---
+     *
+     * ## EXAMPLES
+     *     wp bonnier some inspect facebook
+     */
+    public function inspect($args)
+    {
+        $provider = $args[0];
+        if ($provider === 'facebook') {
+            $data = Storage::get(FacebookRepository::STORAGE_KEY);
+        } else {
+            $data = Storage::get(PinterestRepository::STORAGE_KEY);
+        }
+
+        if (!$data) {
+            WP_CLI::error(sprintf('No data stored for the %s provider!', $provider));
+            return;
+        }
+
+        WP_CLI::success(sprintf('%s items stored!', count($data)));
+        WP_CLI::line(sprintf('Example:'));
+        WP_CLI::line(json_encode($data[0], JSON_PRETTY_PRINT));
+    }
+}

--- a/src/Helpers/Storage.php
+++ b/src/Helpers/Storage.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Bonnier\WP\SoMe\Helpers;
+
+class Storage
+{
+    const GROUP = 'WP_BONNIER_SOCIALMEDIA';
+
+    public static function get(string $key)
+    {
+        $key = hash('md5', $key);
+        if ($data = wp_cache_get($key, self::GROUP)) {
+            return unserialize($data);
+        }
+
+        return null;
+    }
+
+    public static function set(string $key, $value, int $expire = 0): bool
+    {
+        $key = hash('md5', $key);
+        return wp_cache_set($key, serialize($value), self::GROUP, $expire);
+    }
+
+    public static function remember(string $key, callable $callable, int $expire = 0)
+    {
+        if ($data = self::get($key)) {
+            return $data;
+        }
+        $value = $callable();
+        self::set($key, $value, $expire);
+        return $value;
+    }
+
+    public static function rememberForever($key, $callable)
+    {
+        return self::remember($key, $callable, 0);
+    }
+}

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -28,7 +28,7 @@ class OAuthController implements OAuthControllerContract
     public function authorize(WP_REST_Request $request): WP_REST_Response
     {
         $redirectUri = $request->get_param('redirect_uri') ?? $this->homeUri;
-        
+
         $authUrl = $this->provider->getAuthorizationUrl();
         
         $_SESSION['SoMeState'] = $this->provider->getState();
@@ -66,9 +66,10 @@ class OAuthController implements OAuthControllerContract
         return $this->redirect($redirectUri);
     }
     
-    protected function isStateValid(string $state = null): bool
+    protected function isStateValid(?string $state = null): bool
     {
         return isset($_SESSION['SoMeState']) &&
+            $state &&
             hash_equals($_SESSION['SoMeState'], $state);
     }
     

--- a/src/Http/Routes.php
+++ b/src/Http/Routes.php
@@ -36,7 +36,11 @@ class Routes
             $this->homeUrl = preg_replace('#^http://#', 'https://', home_url('/'));
         }
         if (substr($this->homeUrl, 0, 11) !== 'https://api') {
-            $this->homeUrl = str_replace('https://', 'https://api.', $this->homeUrl);
+            if (substr($this->homeUrl, 0, 14) === 'https://admin.') {
+                $this->homeUrl = str_replace('https://admin.', 'https://api.', $this->homeUrl);
+            } else {
+                $this->homeUrl = str_replace('https://', 'https://api.', $this->homeUrl);
+            }
         }
         
         add_action('rest_api_init', function () {

--- a/src/Providers/FacebookProvider.php
+++ b/src/Providers/FacebookProvider.php
@@ -2,6 +2,7 @@
 
 namespace Bonnier\WP\SoMe\Providers;
 
+use Bonnier\WP\SoMe\Helpers\Storage;
 use Bonnier\WP\SoMe\ResourceOwners\FacebookResourceOwner;
 use Bonnier\WP\SoMe\SoMe;
 use League\OAuth2\Client\Provider\AbstractProvider;
@@ -20,7 +21,7 @@ class FacebookProvider extends AbstractProvider
         $this->endpoint = 'https://www.facebook.com/v2.12/';
         $this->graphUrl = 'https://graph.facebook.com/v2.12/';
         $client = SoMe::instance()->getSettings()->getFacebookClient();
-        
+
         parent::__construct([
             'clientId' => $client['client_id'],
             'clientSecret' => $client['client_secret'],
@@ -95,7 +96,16 @@ class FacebookProvider extends AbstractProvider
             );
         }
     }
-    
+
+    public function getResourceOwner(AccessToken $accessToken)
+    {
+        $response = Storage::remember('facebookResourceOwner', function () use ($accessToken) {
+            return parent::fetchResourceOwnerDetails($accessToken);
+        }, 24 * HOUR_IN_SECONDS);
+
+        return $this->createResourceOwner($response, $accessToken);
+    }
+
     /**
      * Generates a resource owner object from a successful resource owner
      * details request.

--- a/src/Repositories/BaseRepository.php
+++ b/src/Repositories/BaseRepository.php
@@ -2,8 +2,10 @@
 
 namespace Bonnier\WP\SoMe\Repositories;
 
+use Bonnier\WP\SoMe\Helpers\Storage;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use Illuminate\Support\Collection;
 use League\OAuth2\Client\Token\AccessToken;
 
 class BaseRepository implements RepositoryContract
@@ -71,6 +73,20 @@ class BaseRepository implements RepositoryContract
             return $result;
         }
         
+        return null;
+    }
+
+    public function storeData(string $key, $data)
+    {
+        Storage::set($key, $data);
+    }
+
+    public function retrieveData(string $key): ?Collection
+    {
+        if ($data = Storage::get($key)) {
+            return collect($data);
+        }
+
         return null;
     }
 

--- a/src/Repositories/FacebookRepository.php
+++ b/src/Repositories/FacebookRepository.php
@@ -2,12 +2,17 @@
 
 namespace Bonnier\WP\SoMe\Repositories;
 
+use Bonnier\WP\SoMe\Helpers\Storage;
 use Bonnier\WP\SoMe\Services\FacebookAccessTokenService;
 use Bonnier\WP\SoMe\Settings\SettingsPage;
+use Illuminate\Support\Collection;
 
 class FacebookRepository extends BaseRepository
 {
+    const STORAGE_KEY = 'instagramPosts';
+
     private $instagramID;
+
     public function __construct()
     {
         $this->instagramID = get_option(SettingsPage::INSTAGRAM_ID);
@@ -16,36 +21,45 @@ class FacebookRepository extends BaseRepository
     
     public function getInstagramAccounts()
     {
-        $accounts = $this->get('me/accounts', [
-            'fields' => 'instagram_business_account.fields(name)'
-        ]);
-        if ($accounts && $accounts->data) {
-            return collect($accounts->data)->map(function ($account) {
-                return [
-                    'id' => $account->instagram_business_account->id,
-                    'name' => $account->instagram_business_account->name
-                ];
-            });
-        }
-        
-        return null;
+        return Storage::remember('instagram-accounts', function () {
+            $accounts = $this->get('me/accounts', [
+                'fields' => 'instagram_business_account.fields(name)'
+            ]);
+            if ($accounts && $accounts->data) {
+                return collect($accounts->data)->map(function ($account) {
+                    return [
+                        'id' => $account->instagram_business_account->id,
+                        'name' => $account->instagram_business_account->name
+                    ];
+                });
+            }
+            return null;
+        }, 24 * HOUR_IN_SECONDS);
     }
     
-    public function getLatestInstagramPosts($limit = 10, $cursor = null, $fields = 'media_url,permalink,caption')
+    public function getLatestInstagramPosts($limit = 10, $offset = 0): ?Collection
     {
-        if (!$this->instagramID) {
-            return null;
+        if ($posts = Storage::get(self::STORAGE_KEY)) {
+            return collect($posts)->slice($offset, $limit);
         }
-        
-        $query = [
-            'limit' => $limit,
-            'fields' => $fields
-        ];
-        
-        if ($cursor) {
-            $query['after'] = $cursor;
+
+        return null;
+    }
+
+    public function fetchInstagramPosts()
+    {
+        $response = $this->get(
+            sprintf('%s/media', $this->instagramID),
+            [
+            'limit' => 500,
+            'fields' => 'media_url,permalink,caption'
+            ]
+        );
+
+        if (isset($response->data)) {
+            return $response->data;
         }
-        
-        return $this->get($this->instagramID . '/media', $query);
+
+        return null;
     }
 }

--- a/src/Repositories/FacebookRepository.php
+++ b/src/Repositories/FacebookRepository.php
@@ -39,15 +39,19 @@ class FacebookRepository extends BaseRepository
     
     public function getLatestInstagramPosts($limit = 10, $offset = 0): ?Collection
     {
-        if ($posts = Storage::get(self::STORAGE_KEY)) {
-            return collect($posts)->slice($offset, $limit);
+        if ($posts = $this->retrieveData(self::STORAGE_KEY)) {
+            return $posts->slice($offset, $limit);
         }
 
         return null;
     }
 
-    public function fetchInstagramPosts()
+    public function storeInstagramPosts()
     {
+        if (!$this->isActive()) {
+            return;
+        }
+
         $response = $this->get(
             sprintf('%s/media', $this->instagramID),
             [
@@ -57,9 +61,7 @@ class FacebookRepository extends BaseRepository
         );
 
         if (isset($response->data)) {
-            return $response->data;
+            $this->storeData(self::STORAGE_KEY, $response->data);
         }
-
-        return null;
     }
 }

--- a/src/Repositories/PinterestRepository.php
+++ b/src/Repositories/PinterestRepository.php
@@ -2,7 +2,6 @@
 
 namespace Bonnier\WP\SoMe\Repositories;
 
-use Bonnier\WP\SoMe\Helpers\Storage;
 use Bonnier\WP\SoMe\Services\PinterestAccessTokenService;
 use Illuminate\Support\Collection;
 
@@ -17,24 +16,25 @@ class PinterestRepository extends BaseRepository
     
     public function getLatestPins($limit = 10, $offset = 0): ?Collection
     {
-        if ($posts = Storage::get(self::STORAGE_KEY)) {
-            return collect($posts)->slice($offset, $limit);
+        if ($pins = $this->retrieveData(self::STORAGE_KEY)) {
+            return $pins->slice($offset, $limit);
         }
 
         return null;
     }
 
-    public function fetchPins()
+    public function storePins()
     {
+        if (!$this->isActive()) {
+            return;
+        }
         $response = $this->get('v1/me/pins', [
             'limit' => 500,
             'fields' => 'url,note,media,image'
         ]);
 
         if (isset($response->data)) {
-            return $response->data;
+            $this->storeData(self::STORAGE_KEY, $response->data);
         }
-
-        return null;
     }
 }

--- a/src/SoMe.php
+++ b/src/SoMe.php
@@ -2,6 +2,7 @@
 
 namespace Bonnier\WP\SoMe;
 
+use Bonnier\WP\SoMe\Commands\WarmStorage;
 use Bonnier\WP\SoMe\Http\Routes;
 use Bonnier\WP\SoMe\Repositories\SoMeRepository;
 use Bonnier\WP\SoMe\Settings\SettingsPage;
@@ -66,6 +67,9 @@ class SoMe
 
     public function bootstrap()
     {
+        if (defined('WP_CLI') && WP_CLI) {
+            WarmStorage::register();
+        }
         $this->routes = new Routes();
         $this->settings = new SettingsPage();
         $this->soMeRepo = new SoMeRepository();

--- a/wp-bonnier-some.php
+++ b/wp-bonnier-some.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Bonnier SoMe
- * Version: 1.1.0
+ * Version: 1.1.1
  * Plugin URI: https://github.com/BenjaminMedia/wp-bonnier-some
  * Description: Plugin for integrating social media into the application.
  * Author: Bonnier


### PR DESCRIPTION
In order to minimize the amount of calls going to Facebook and Pinterest, 500 posts will now be saved in cache.
## New Commands
To warm cache, run the command `wp bonnier some warm`
Inspect the cache by running the command `wp bonnier some inspect <provider>`
Example: `wp bonnier some inspect facebook`
## NOTE
Redis Object Cache plugin needs to be activated and enabled!